### PR TITLE
Remove Telegram Icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,12 +133,6 @@
             </a>
           </div>
           <div>
-            <a href="https://t.me/joinchat/BzYbR0NlHezSUou42Q78JQ" target="_blank" rel="noopener noreferrer external">
-              <span class="fa fa-send">
-              </span>
-            </a>
-          </div>
-          <div>
             <a href="http://github.com/linuxchixin" target="_blank" rel="noopener noreferrer external">
               <span class="fa fa-github-alt">
               </span>


### PR DESCRIPTION
Since the Telegram Link is not functional, It makes sense to remove it